### PR TITLE
Update code from props correctly

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -184,7 +184,7 @@ class Editor extends Component {
 
   componentWillReceiveProps({ code }) {
     if (code !== this.props.code) {
-      const html = prism(normalizeCode(this.props.code))
+      const html = prism(normalizeCode(code))
       this.setState({ html })
     }
   }


### PR DESCRIPTION
As-is, the editor does not update its code when it receives new code in props.
Instead, it sets the code to the last value, instead of the next value.